### PR TITLE
Given a string, capitalise the letters on even indexes and odd indexes

### DIFF
--- a/Java/AlternativeCapitalise/AlternateCapitalise.java
+++ b/Java/AlternativeCapitalise/AlternateCapitalise.java
@@ -1,0 +1,28 @@
+public class AlternateCapitalise {
+
+	public static void main(String[] args) {
+		String[] result = capitalise("thisisatest");
+		
+		System.out.println(result[0]);
+		System.out.println(result[1]);
+	}
+
+	public static String[] capitalise(String s) {
+		String odds = "";
+		String evens = "";
+
+		for (int i = 0; i < s.length(); i++) {
+			String letter = s.substring(i, i + 1);
+			
+			if (i % 2 == 0) {
+				odds += letter.toUpperCase();
+				evens += letter.toLowerCase();
+			} else {
+				odds += letter.toLowerCase();
+				evens += letter.toUpperCase();
+			}
+		}
+
+		return new String[] { odds, evens };
+	}
+}

--- a/Java/AlternativeCapitalise/AlternateCapitaliseTests.java
+++ b/Java/AlternativeCapitalise/AlternateCapitaliseTests.java
@@ -1,0 +1,20 @@
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class AlternateCapitaliseTests{
+    @Test
+    public void lowerCaseLettersAreCapitalisedCorrectly(){
+        assertArrayEquals(new String[]{"GiThUb", "gItHuB"}, AlternateCapitalise.capitalise("github"));
+    }
+    
+    @Test
+    public void upperCaseLettersAreCapitalisedCorrectly(){
+        assertArrayEquals(new String[]{"CaPiTaLiSe", "cApItAlIsE"}, AlternateCapitalise.capitalise("CAPITALISE"));
+    }
+    
+    @Test
+    public void mixedCaseLettersAreCapitalisedCorrectly(){
+        assertArrayEquals(new String[]{"ThIsIsAtEsT", "tHiSiSaTeSt"}, AlternateCapitalise.capitalise("ThisIsATest"));
+    }
+}

--- a/Java/AlternativeCapitalise/README.md
+++ b/Java/AlternativeCapitalise/README.md
@@ -1,0 +1,11 @@
+
+**Alternate Capitalisation**
+
+Given a string, capitalise the letters on even indexes and odd indexes separately, return as shown below. Letters at index 0 will be considered even.
+
+For example:
+
+    capitalise("hello") = ['HeLlO', 'hElLo']. 
+
+
+Completed as part of a [CodeWars challenge](https://www.codewars.com/kata/59cfc000aeb2844d16000075).


### PR DESCRIPTION
Given a string, capitalise the letters on even indexes and odd indexes separately, return as shown below. Letters at index 0 will be considered even. For example:     capitalise("hello") = ['HeLlO', 'hElLo']. 